### PR TITLE
readme: update readme after 18.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,96 +32,119 @@ These release notes are also published in HTML at the URL below.
 
 https://docs.tenstorrent.com/tt-zephyr-platforms/release/release-notes-18.12.html
 
-<!-- H3 Performance Improvements, if applicable -->
+## Major Highlights
 
-### Performance Improvements
+- **Enhanced Power Management**: New MRISC PHY powerdown/wakeup support and power command capabilities
+- **Improved SMBus Reliability**: Enhanced error detection, logging, and robustness for CM2DM operations
+- **Advanced Developer Tooling**: New stack dump utilities and improved console tooling
+- **Zephyr v4.3.0 Alignment**: Updated to latest Zephyr pre-release for better upstream compatibility
+- **Streamlined Board Support**: Focused support on production devices
 
-* soc: tt_blackhole: enable hardware floating-point in SMC FW
+## New Features
 
-<!-- H3 New and Experimental Features, if applicable -->
-<!-- H3 External Project Collaboration Efforts, if applicable -->
+### Power Management
+- **lib: bh_arc**: Added support for MRISC PHY powerdown/wakeup operations
+- **lib: bh_arc**: Implemented new Power command functionality
+- **boards: tt_blackhole**: Enabled AICLK PPM in firmware table for Galaxy boards
+- **boards: tenstorrent**: Applied more conservative TDP limits for P300 boards
 
-<!-- H3 Stability Improvements, if applicable -->
+### Communication & Protocols
+- **app: dmc**: Added support for SMBus block process call (pcall) operations
+- **drivers: smbus: stm32**: Enhanced with block read capabilities
+- **app: smc**: Added overlay configuration to build DMFW with I2C shell enabled
 
-### Stability Improvements
+### Developer & Debug Tools
+- **scripts**: New `dump_smc_stack.py` utility for on-demand SMC state analysis
+- **scripts: tooling**: Enhanced `tt-console` with PCIe rescan skip option for smooth TT-KMD transitions (2.3.0 to 2.4.1)
+- **scripts**: Updated `blackhole_recovery` with improved status messaging and increased delays
 
-* boards: tt_blackhole: p150c: correct tdp_limit & tdc_limits
-* scripts: recover-blackhole: add recovery bundle scripting in-tree
-* patches: Fix smbus PEC correction patch
-* ci: workflows: hardware-long: update metal container version and test p300a
-* app: dmc: Move MFD, PWM and sensor configs to prj.conf
-* scripts: tooling: vuart: report error if card reads as `0xffff_ffff`
+## Stability & Robustness Improvements
 
-<!-- H1 Security vulnerabilities fixed? -->
+### Communication Reliability
+- **CM2DM Protocol**: Enhanced robustness with detection of duplicate SMBus messages and improved error handling
+- **lib: tenstorrent: bh_arc**: Improved error logging in SPI EEPROM operations
 
-<!-- H2 API Changes, if applicable -->
+### System Reliability
+- **app: dmc**: Implemented fine-grained DMC events, replacing the previous single "wakeup" flag approach
+- **regulators**: Fixed Galaxy SerDes programming regression
+- **boards: tenstorrent**: Reduced P300 I2C clock speeds to minimize packet errors
+- **lib: bh_chip**: Optimized I2C gate handling during BH ARC reset operations
 
-<!-- H3 Removed APIs, H3 Deprecated APIs, H3 New APIs, if applicable -->
+### Infrastructure
+- **CI/CD**: Migrated to centralized Docker containers hosted at `ghcr.io/tenstorrent`
+- **scripts: tooling**: Reworked logging macros with new rate-limited variants
 
-<!-- UL PCIe -->
-<!-- UL DDR -->
-<!-- UL Ethernet -->
-<!-- UL Telemetry -->
-<!-- UL Debug / Developer Features -->
+### Wormhole Updates
+- **blobs**: Updated Wormhole firmware blob
+  - CMFW 2.36.0.0
+    - Attempt to enter A3 state on both chips of n300 before triggering
+      reset
+    - Fix VR addresses for Nebula CB P0V8_GDDR_VDD and P1V35_MVDDQ
+    - Update Nebula CB SPI parameters
+      - Disable DRAM training at boot
+      - Voltage margin = 0
+      - P0V8_GDDR_VDD override to 850 mV
+      - P1V35_MVDDQ override to 1.35 V
+      - Enable additional DRAM training parameters
+  - ERISC 6.7.1.0
+    - Enable partial response phase detector mode to compensate jitter lanes
+    - Initial support for per asic resetting in WH Galaxy
 
-### Debug / Developer Features
+## API Changes
 
-* `tt-zephyr-platforms` documentation is now available online at https://docs.tenstorrent.com/tt-zephyr-platforms 🙌🪁
-  * doc: getting_started: move contents from README.md to getting started guide, and publish to HTML
-  * doc: develop: add documentation for tracing
-* ci: build-native: publish tt-console and tt-tracing artifacts
-  * previously, users needed to build these binaries themselves with `make -C scripts/tooling`. Now they are built on every commit.
-* ci: release: ensure build artifacts for all board revisions are in zip
-* scripts: tt_boot_fs: ls: add hexdump functionality when verbose >= 2
-  * this allows us to inspect all contents of TT Boot FS .bin files without breaking out a separate hex editor
-* bh_arc: tt_shell: add shell support
-  * a common location for custom Tenstorrent shell commands
-  * print telemetry data with `telem` sub-command
-  * read (and write) asic state with `asic_state` sub-command
-* app: dmc: enable logging via DMC SMBUS path
-  * first logs to a local ringbuffer, and then data is sent over smbus from DMC to SMC
-  * users should now be able to view DMC logs with `tt-console -c 2`
+### Breaking Changes
+- **lib: bh_arc**: Renamed `msg_type` to `tt_smc_msg`
+  - Header file changed from `tenstorrent/msg_type.h` to `tenstorrent/smc_msg.h`
+  - **Migration Required**: Update include statements in existing code
 
-<!-- UL Drivers -->
+### Platform Updates
+- **zephyr: patches**: Added patch for SPI-NOR erase-block-size property support
 
-### Drivers
+## Zephyr Integration
 
-* drivers: sensor: pvt: integrate pvt driver, add tolerance in tests, read efused temperature calibration
-* drivers: smbus: add platform-independent `zephyr,smbus-target` driver (should be upstreamed shortly)
+### Version Update
+- **manifest**: Updated to Zephyr v4.3.0-pre
+  - Snapshot from Zephyr mainline prior to v4.3.0 feature freeze (October 24th)
+  - Minimized in-tree patches through active upstream contribution
 
-<!-- UL Libraries -->
+### Upstream Contributions
+- Enhanced PWM API test suite with cleaner platform-specific conditionals
+- Fixed I2C DesignWare target implementation
+- Improved SMBus STM32 driver with proper block write byte count handling
+- Added IRQ lock protection for CTF tracing timestamp generation
+- Extended interrupt controller support for multiple DesignWare instances
+- Implemented "safe" API variants for `k_event_wait()` in kernel events
 
-<!-- H2 New Samples, if applicable -->
+## Documentation Improvements
 
-<!-- UL PCIe -->
-<!-- UL DDR -->
-<!-- UL Ethernet -->
-<!-- UL Telemetry -->
-<!-- UL Debug / Developer Features -->
-<!-- UL Drivers -->
-<!-- UL Libraries -->
+### Enhanced Documentation
+- **lib: bh_arc**: Comprehensive Doxygen documentation for host-to-SMC message types
+- **doxygen**: Added supported boards reference links
+- **doc**: New contribution and coding guidelines
+- **docs**: Added CI job status visualization on project landing page
 
-<!-- H2 Other Notable Changes, if applicable -->
+### Developer Guidance
+- **doc**: Added code update workflow snippet: `west patch clean; west update; west patch apply`
+- **lib: bh_arc**: Documented unused commands for better API clarity
+- **doc**: Improved version handling using project settings from `conf.py`
 
-<!-- UL PCIe -->
-<!-- UL DDR -->
-<!-- UL Ethernet -->
-<!-- UL Telemetry -->
-<!-- UL Debug / Developer Features -->
-<!-- UL Drivers -->
-<!-- UL Libraries -->
+## Board Support Changes
 
-<!-- H2 New Boards, if applicable -->
+### Removed Support
+- **Removed P100 (Scrappy) Support**:
+  - P100 was an internal engineering unit used during initial bringup and testing
+  - Support removed to focus resources on consumer-facing devices
+  - **Migration Impact**: P100 users must transition to supported production boards
 
 ## Migration guide
 
-An overview of required and recommended changes to make when migrating from the previous v18.10.0 release can be found in [v18.12 Migration Guide](https://github.com/tenstorrent/tt-zephyr-platforms/tree/main/doc/release/migration-guide-18.12.md).
+An overview of required and recommended changes to make when migrating from the previous v18.11.0 release can be found in [v18.12 Migration Guide](https://github.com/tenstorrent/tt-zephyr-platforms/tree/main/doc/release/migration-guide-18.12.md).
 
 ## Full ChangeLog
 
-The full ChangeLog from the previous v18.10.0 release can be found at the link below.
+The full ChangeLog from the previous v18.11.0 release can be found at the link below.
 
-https://github.com/tenstorrent/tt-zephyr-platforms/compare/v18.10.0...v18.12.0
+https://github.com/tenstorrent/tt-zephyr-platforms/compare/v18.11.0...v18.12.0
 
 ## Experiments
 


### PR DESCRIPTION
For some reason, vs code did not actually save the edits made to the README.md file when 18.12 was released.

Adding them now to ensure that release notes are consistent.