### PR TITLE
Add archive notice and redirect to tt-system-firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > 
 > Please visit the new repository for the latest firmware releases, updates, and to contribute or report issues.
 
-## Official Repository
+## Legacy Repository (Archived)
 
 [https://github.com/tenstorrent/tt-firmware](https://github.com/tenstorrent/tt-firmware) (**ARCHIVED**)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # tt-firmware
 
+> **⚠️ ARCHIVED: This repository is now archived and no longer maintained.**
+> 
+> **All future firmware development and releases have moved to: [tenstorrent/tt-system-firmware](https://github.com/tenstorrent/tt-system-firmware)**
+> 
+> Please visit the new repository for the latest firmware releases, updates, and to contribute or report issues.
+
 ## Official Repository
 
-[https://github.com/tenstorrent/tt-firmware](https://github.com/tenstorrent/tt-firmware)
+[https://github.com/tenstorrent/tt-firmware](https://github.com/tenstorrent/tt-firmware) (**ARCHIVED**)
 
 This repository contains firmware binaries for Tenstorrent's Wormhole and Blackhole hardware. To see the open source files and how to get started with our development environment, visit [`tt-zephyr-platforms`](https://github.com/tenstorrent/tt-zephyr-platforms).
+
+**For new firmware releases and development, please use [tenstorrent/tt-system-firmware](https://github.com/tenstorrent/tt-system-firmware).**
 
 ## What is this Firmware?
 
@@ -18,7 +26,11 @@ If you are interested in the extent that applications interact with this firmwar
 
 ## Getting Started
 
-Download the latest firmware bundle from the [Releases page](https://github.com/tenstorrent/tt-firmware/releases), and use our [`tt-flash`](https://github.com/tenstorrent/tt-flash) utility to flash the bundle onto your Wormhole or Blackhole hardware. Refer to the release notes for any minimum `tt-flash` version required for a given firmware release.
+**Note: For the latest firmware releases, please visit [tenstorrent/tt-system-firmware](https://github.com/tenstorrent/tt-system-firmware).**
+
+Download firmware bundles from the [tt-system-firmware Releases page](https://github.com/tenstorrent/tt-system-firmware/releases), and use our [`tt-flash`](https://github.com/tenstorrent/tt-flash) utility to flash the bundle onto your Wormhole or Blackhole hardware. Refer to the release notes for any minimum `tt-flash` version required for a given firmware release.
+
+Historical firmware releases from this archived repository can still be found on the [legacy Releases page](https://github.com/tenstorrent/tt-firmware/releases).
 
 ## Experiments
 

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,4 +1,9 @@
 # tt-firmware - experiments
+
+> **⚠️ ARCHIVED: This repository is now archived.**
+> 
+> **All future firmware development has moved to: [tenstorrent/tt-system-firmware](https://github.com/tenstorrent/tt-system-firmware)**
+
 Firmware bundles built off of the latest available firmware release with minor modifications to address specific issues.
 
 ## Available Firmware

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,8 +1,8 @@
 # tt-firmware - experiments
 
-> **⚠️ ARCHIVED: This repository is now archived.**
+> **⚠️ ARCHIVED: This repository is no longer maintained and is now archived.**
 > 
-> **All future firmware development has moved to: [tenstorrent/tt-system-firmware](https://github.com/tenstorrent/tt-system-firmware)**
+> **No new releases will be made from this repository. All future firmware development and releases have moved to: [tenstorrent/tt-system-firmware](https://github.com/tenstorrent/tt-system-firmware).**
 
 Firmware bundles built off of the latest available firmware release with minor modifications to address specific issues.
 


### PR DESCRIPTION
## Summary

This PR adds prominent archive notices to the repository documentation to inform users that this repository is being archived and all future firmware development has moved to `tenstorrent/tt-system-firmware`.

## Changes

- **README.md**: Added prominent archive notice at the top with warning icon
- **README.md**: Updated "Getting Started" section to direct users to the new repository for latest releases
- **README.md**: Added note about historical releases remaining accessible in this archived repo
- **experiments/README.md**: Added archive notice

## Impact

Users visiting this repository will immediately see:
- ⚠️ Clear notification that the repository is archived
- 🔗 Link to the new repository location: [tenstorrent/tt-system-firmware](https://github.com/tenstorrent/tt-system-firmware)
- 📝 Guidance on where to find new firmware releases and contribute

This ensures a smooth transition for all users and contributors.